### PR TITLE
Use EquipmentElement instead of ItemObject

### DIFF
--- a/ForgeOverhaul/ForgeOverhaul/HarmonyFixes/SmeltingVMFixes/FastSmeltHotkeyFix.cs
+++ b/ForgeOverhaul/ForgeOverhaul/HarmonyFixes/SmeltingVMFixes/FastSmeltHotkeyFix.cs
@@ -33,7 +33,7 @@ namespace ForgeOverhaul.HarmonyFixes.SmeltingVMFixes
 							&& heroStamina >= energyCost
 							&& charcoalAmount >= 1 ; i++)
 						{
-							smithingBehavior.DoSmelting(currentCraftingHero, ((SmeltingItemVM)Traverse.Create(__instance).Field("_currentSelectedItem").GetValue()).Item);
+							smithingBehavior.DoSmelting(currentCraftingHero, ((SmeltingItemVM)Traverse.Create(__instance).Field("_currentSelectedItem").GetValue()).EquipmentElement);
 							__instance.RefreshList();
 							charcoalAmount--;
 							heroStamina -= energyCost;
@@ -41,7 +41,7 @@ namespace ForgeOverhaul.HarmonyFixes.SmeltingVMFixes
 					}
 					else
 					{
-						smithingBehavior.DoSmelting(currentCraftingHero, ((SmeltingItemVM)Traverse.Create(__instance).Field("_currentSelectedItem").GetValue()).Item);
+						smithingBehavior.DoSmelting(currentCraftingHero, ((SmeltingItemVM)Traverse.Create(__instance).Field("_currentSelectedItem").GetValue()).EquipmentElement);
 					}
 				}
 			}


### PR DESCRIPTION
#1 Fixes a crash with 1.3.1 and 1.4.0 where it tries to use an ItemObject in place of EquipmentElement.